### PR TITLE
ft: make update endpoints for user and article

### DIFF
--- a/routes/article.js
+++ b/routes/article.js
@@ -42,5 +42,27 @@ const createArticle = async (req, res) => {
   res.send(article);
 };
 
+const updateArticle = async (req, res) => {
+  try {
+    const article = Article.findOne({ _id: req.params.id });
+    if (req.body.title) {
+      article.title = req.body.title;
+    }
+    if (req.body.content) {
+      notep;
+      article.content = req.body.content;
+    }
+    if (req.body.articleThumbnail) {
+      article.articleThumbnail = req.body.articleThumbnail;
+    }
+    await article.save();
+    res.send(article);
+  } catch {
+    res.status(404);
+    res.send({ error: "Article doesn't exist" });
+  }
+};
+
 router.route("/").post(upload.single("articleThumbnail"), createArticle);
+router.route("/:id").put(updateArticle);
 module.exports = router;

--- a/routes/user.js
+++ b/routes/user.js
@@ -12,5 +12,27 @@ const createUser = async (req, res) => {
   res.send(user);
 };
 
+const updateUser = async (req, res) => {
+  try {
+    const user = User.findOne({ _id: req.params.id });
+    if (req.body.username) {
+      user.username = req.body.username;
+    }
+    if (req.body.email) {
+      user.email = req.body.email;
+    }
+    if (req.body.password) {
+      user.password = req.body.password;
+    }
+
+    await user.save();
+    res.send(user);
+  } catch {
+    res.status(404);
+    res.send({ error: "User doesn't exist" });
+  }
+};
+
 router.route("/").post(createUser);
+router.route("/:id").put(updateUser);
 module.exports = router;


### PR DESCRIPTION
## what
make update endpoints for user and article

## why
to update, a request is sent to the server which should have a way to respond. Endpoints are 'a way to respond'. These ones are specifically for updating a user and an article

## how
using mongodb's .findOne({_id:req.params.id}) method, a document with the corresponding _id is retrieved and its content is modified according to what was passed in the body (After totally successful testing it should work like this).
For now, it gave an "article doesn't exist" error

## testing
used Postman to test and article passed with an "article doesn't exist" error.
test user afterwards