### PR TITLE
ft: delete apis for both user and article

### DIFF
--- a/routes/article.js
+++ b/routes/article.js
@@ -49,7 +49,6 @@ const updateArticle = async (req, res) => {
       article.title = req.body.title;
     }
     if (req.body.content) {
-      notep;
       article.content = req.body.content;
     }
     if (req.body.articleThumbnail) {
@@ -63,6 +62,16 @@ const updateArticle = async (req, res) => {
   }
 };
 
+const deleteArticle = async (req, res) => {
+  try {
+    await Article.deleteOne({ _id: req.params.id });
+    res.status(204).send("Article successfully deleted");
+  } catch {
+    res.status(404);
+    res.send({ error: "Article was not found - Couldn't delete" });
+  }
+};
+
 router.route("/").post(upload.single("articleThumbnail"), createArticle);
-router.route("/:id").put(updateArticle);
+router.route("/:id").put(updateArticle).delete(deleteArticle);
 module.exports = router;

--- a/routes/user.js
+++ b/routes/user.js
@@ -33,6 +33,16 @@ const updateUser = async (req, res) => {
   }
 };
 
+const deleteUser = async (req, res) => {
+  try {
+    await User.deleteOne({ _id: req.params.id });
+    res.status(204).send({ message: "User successfully deleted" });
+  } catch {
+    res.status(404);
+    res.send({ error: "User was not found - Couldn't delete" });
+  }
+};
+
 router.route("/").post(createUser);
-router.route("/:id").put(updateUser);
+router.route("/:id").put(updateUser).delete(deleteUser);
 module.exports = router;


### PR DESCRIPTION
## what
made delete apis for both user and article

## why
before adding the apis, you couldn't delete an article or user that you wanted to

## how
using mongodb's .findOne({_id:req.params.id}) method, a document stored in the database that corresponds to the id passed in the parameters is retrieved and afterwards, using the .deleteOne({_id:req.params.id}), the document is deleted.

## testing
It will give a message "User/Article successfully deleted"