### PR TITLE
add swagger documentation

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,23 @@ const articleRoutes = require("./routes/article");
 const express = require("express");
 const app = express();
 
+const swaggerUi = require("swagger-ui-express");
+
 const path = require("path");
 mongoose
   .connect("mongodb://0.0.0.0:27017/ATLP-Portfolio", {
     useNewUrlParser: true,
   })
   .then(() => {
+    const swaggerDocs = require("./swagger.json");
+    app.use(
+      "/documentation",
+      swaggerUi.serve,
+      swaggerUi.setup(swaggerDocs, false, {
+        docExpansion: "none",
+      })
+    );
+
     app.use(express.json());
     app.use("/uploads", express.static("uploads"));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "body-parser": "^1.20.0",
         "express": "^4.17.3",
         "express-upload": "^0.1.0",
+        "joi": "^17.6.0",
         "mongoose": "^6.3.0"
       },
       "devDependencies": {
@@ -19,6 +20,37 @@
         "multer": "^1.4.4",
         "nodemon": "^2.0.15"
       }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+      "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
@@ -1507,6 +1539,18 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "node_modules/joi": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
+      "integrity": "sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3077,6 +3121,37 @@
     }
   },
   "dependencies": {
+    "@hapi/hoek": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+      "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/address": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -4191,6 +4266,18 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "joi": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
+      "integrity": "sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
     },
     "js-yaml": {
       "version": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "express": "^4.17.3",
         "express-upload": "^0.1.0",
         "joi": "^17.6.0",
-        "mongoose": "^6.3.0"
+        "mongoose": "^6.3.0",
+        "swagger-ui-express": "^4.3.0"
       },
       "devDependencies": {
         "mocha": "^9.2.2",
@@ -2739,6 +2740,25 @@
         "node": ">=4"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.10.3.tgz",
+      "integrity": "sha512-eR4vsd7sYo0Sx7ZKRP5Z04yij7JkNmIlUQfrDQgC+xO5ABYx+waabzN+nDsQTLAJ4Z04bjkRd8xqkJtbxr3G7w=="
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.3.0.tgz",
+      "integrity": "sha512-jN46SEEe9EoXa3ZgZoKgnSF6z0w3tnM1yqhO4Y+Q4iZVc8JOQB960EZpIAz6rNROrDApVDwcMHR0mhlnc/5Omw==",
+      "dependencies": {
+        "swagger-ui-dist": ">=4.1.3"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0"
+      }
+    },
     "node_modules/temp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.5.1.tgz",
@@ -5173,6 +5193,19 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "swagger-ui-dist": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.10.3.tgz",
+      "integrity": "sha512-eR4vsd7sYo0Sx7ZKRP5Z04yij7JkNmIlUQfrDQgC+xO5ABYx+waabzN+nDsQTLAJ4Z04bjkRd8xqkJtbxr3G7w=="
+    },
+    "swagger-ui-express": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.3.0.tgz",
+      "integrity": "sha512-jN46SEEe9EoXa3ZgZoKgnSF6z0w3tnM1yqhO4Y+Q4iZVc8JOQB960EZpIAz6rNROrDApVDwcMHR0mhlnc/5Omw==",
+      "requires": {
+        "swagger-ui-dist": ">=4.1.3"
       }
     },
     "temp": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "express": "^4.17.3",
     "express-upload": "^0.1.0",
     "joi": "^17.6.0",
-    "mongoose": "^6.3.0"
+    "mongoose": "^6.3.0",
+    "swagger-ui-express": "^4.3.0"
   },
   "devDependencies": {
     "mocha": "^9.2.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "body-parser": "^1.20.0",
     "express": "^4.17.3",
     "express-upload": "^0.1.0",
+    "joi": "^17.6.0",
     "mongoose": "^6.3.0"
   },
   "devDependencies": {

--- a/swagger.json
+++ b/swagger.json
@@ -1,0 +1,94 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Documentation of all bus booking APIs",
+    "version": "1.0.0",
+    "title": "Grace Fidele's Portfolio APIs",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Grace Fidele",
+      "url": "https://vercel.app/grace-fidele-my-brand",
+      "email": "gngrace10@gmail.com"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "tags": [
+    {
+      "name": "Article",
+      "description": "Article-related APIs"
+    }
+  ],
+  "paths": {
+    "/api/articles": {
+      "get": {
+        "tags": ["Article"],
+        "summary": "Get all articles",
+        "description": "Get all articles",
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "All articles"
+          }
+        }
+      },
+      "post": {
+        "tags": ["Article"],
+        "summary": "Post a new article",
+        "description": "Get all articles",
+        "produces": ["application/json"],
+        "consumes": ["application/json"],
+        "parameters": [
+          {
+            "in": "formData",
+            "name": "title",
+            "type": "string",
+            "example": "Proper commits are written like...",
+            "required": true
+          },
+          {
+            "in": "formData",
+            "name": "content",
+            "type": "string",
+            "example": "Proper commits are written like... is the title of this blog!"
+          },
+          {
+            "in": "formData",
+            "name": "articleThumbnail",
+            "type": "file",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "  All articles"
+          }
+        }
+      }
+    },
+    "/api/articles/{id}": {
+      "delete": {
+        "tags": ["Article"],
+        "summary": "Delete an article by ID",
+        "description": "Delete an article by ID",
+        "produces": ["application/json"],
+        "consumes": ["application/json"],
+        "parameters": [
+          {
+            "name": "ArticleId",
+            "in": "path",
+            "description": "Article's id",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Article deleted"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## what
add swagger documentation

## why
swagger documentation gives a UI to backend apis

## how
by the npm package swagger-ui-express and its methods; .serve() and .setup()
in the specific _swagger.json_ file also, the real documentation is done

## testing
using the endpoint (in this case localhost:3008/documentation), it will display what's in _swagger.json_ in the browser or postman

## screenshots
showing that the documentation endpoint is working
![Screenshot (1168)](https://user-images.githubusercontent.com/66947850/164781753-26a65a10-036e-4275-9008-ec50222d2fef.png)
