### PR TITLE
fix: export server properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,4 +31,4 @@ mongoose
 const server = app.listen(3008, () => {
   console.log("Server has started!");
 });
-exports.server = server;
+module.exports = server;


### PR DESCRIPTION
## what
fix: export server properly

## why
the server that is returned by express().listen() was not properly exported so that it could be used in articleTest.spec.js. Thus, all the tests failed and the logs pointed to the server with a TypeError: _app_.address is not a function

## how
before I had exported by _exports.server=server_ which was wrong. Now, it is simply and correctly _module.exports=server_

## testing
now the two written tests are passing

## screenshots
![image](https://user-images.githubusercontent.com/66947850/165138418-bee22825-4d1e-44f5-ab93-0f33b9fffb11.png)
.