### PR TITLE
document get all articles' api

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -73,25 +73,6 @@
       }
     },
     "/api/articles/{id}": {
-      "get": {
-        "tags": ["Article"],
-        "summary": "Get an article by ID",
-        "description": "Get an article by ID",
-        "produces": ["application/json"],
-        "parameters": [
-          {
-            "name": "ArticleId",
-            "in": "path",
-            "description": "Article's id",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Article successfully retrieved"
-          }
-        }
-      },
       "delete": {
         "tags": ["Article"],
         "summary": "Delete an article by ID",
@@ -109,6 +90,18 @@
         "responses": {
           "200": {
             "description": "Article deleted"
+          }
+        }
+      }
+    },
+    "/api/users/": {
+      "get": {
+        "tags": ["User"],
+        "description": "Get all registered users",
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "All users"
           }
         }
       }

--- a/swagger.json
+++ b/swagger.json
@@ -73,6 +73,25 @@
       }
     },
     "/api/articles/{id}": {
+      "get": {
+        "tags": ["Article"],
+        "summary": "Get an article by ID",
+        "description": "Get an article by ID",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "ArticleId",
+            "in": "path",
+            "description": "Article's id",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Article successfully retrieved"
+          }
+        }
+      },
       "delete": {
         "tags": ["Article"],
         "summary": "Delete an article by ID",


### PR DESCRIPTION
## What
document get all articles' api

## Why
to view and use the api via swagger

## How
in the swagger.json file, under predefined "Article" tag and _get_ method, the api is added and swagger knows what to do with it.

## Testing
At locahost:port/documentation where swagger runs, the api was added and when you try it, it returns the available user(s).

## Screenshot
![image](https://user-images.githubusercontent.com/66947850/166419537-c62b0372-6cba-4d29-a86a-1ea754223ccd.png)
